### PR TITLE
minor fix to rust-analyzer binary

### DIFF
--- a/modules/lsp.nix
+++ b/modules/lsp.nix
@@ -32,6 +32,7 @@ _: {
       enable = true;
       dap.enable = true;
       crates.enable = true;
+      lsp.package = ["rustup" "run" "stable" "rust-analyzer"];
     };
 
     go = {


### PR DESCRIPTION
It is prefered to use your own binary to avoid conflicts in rust toolchain version.